### PR TITLE
feat(www): add public thoughts list and detail pages with SEO

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -29,14 +29,15 @@
     "clsx": "2.1.0",
     "date-fns": "^3.6.0",
     "isbot": "5.1.0",
+    "marked": "^17.0.4",
     "react": "18.2.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.51.5",
     "tailwind-merge": "2.2.1",
     "tailwindcss-animate": "1.0.7",
-    "zod": "^3.23.8",
-    "ts-pattern": "^5.1.1"
+    "ts-pattern": "^5.1.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.3",

--- a/apps/www/src/components/thoughts/tag-list.tsx
+++ b/apps/www/src/components/thoughts/tag-list.tsx
@@ -1,0 +1,15 @@
+type TagListProps = {
+  tags: string[];
+};
+
+export function TagList({tags}: TagListProps) {
+  return (
+    <div className="flex gap-2">
+      {tags.map((tag) => (
+        <span key={tag} className="rounded-full bg-warm-100 px-2.5 py-0.5 text-xs text-warm-600">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/www/src/components/thoughts/thought-card.tsx
+++ b/apps/www/src/components/thoughts/thought-card.tsx
@@ -1,0 +1,32 @@
+import {Link} from '@tanstack/react-router';
+import {format} from 'date-fns';
+import {TagList} from './tag-list';
+
+type ThoughtCardProps = {
+  title: string;
+  slug: string;
+  description: string | null;
+  tags: string[] | null;
+  published_at: string;
+};
+
+export function ThoughtCard({title, slug, description, tags, published_at}: ThoughtCardProps) {
+  return (
+    <Link
+      to="/thoughts/$slug"
+      params={{slug}}
+      className="block rounded-lg border border-warm-200 bg-white p-6 transition-colors hover:border-warm-400"
+    >
+      <h2 className="font-serif text-xl text-warm-800">{title}</h2>
+      <time className="mt-1 text-sm text-warm-500">
+        {format(new Date(published_at), 'MMMM d, yyyy')}
+      </time>
+      {description && <p className="mt-2 text-warm-600">{description}</p>}
+      {tags && tags.length > 0 && (
+        <div className="mt-3">
+          <TagList tags={tags} />
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/apps/www/src/components/thoughts/thought-content.tsx
+++ b/apps/www/src/components/thoughts/thought-content.tsx
@@ -1,0 +1,11 @@
+import {marked} from 'marked';
+
+type ThoughtContentProps = {
+  content: string;
+};
+
+export function ThoughtContent({content}: ThoughtContentProps) {
+  const html = marked(content) as string;
+
+  return <div className="prose prose-warm max-w-none" dangerouslySetInnerHTML={{__html: html}} />;
+}

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ThoughtsRouteImport } from './routes/thoughts'
 import { Route as RunningRouteImport } from './routes/running'
 import { Route as ResumeRouteImport } from './routes/resume'
 import { Route as ReadmeRouteImport } from './routes/readme'
@@ -16,7 +17,9 @@ import { Route as PrintResumeRouteImport } from './routes/print-resume'
 import { Route as HealthcheckRouteImport } from './routes/healthcheck'
 import { Route as AdminRouteRouteImport } from './routes/admin/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ThoughtsIndexRouteImport } from './routes/thoughts.index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
+import { Route as ThoughtsSlugRouteImport } from './routes/thoughts.$slug'
 import { Route as AdminStreakRouteImport } from './routes/admin/streak'
 import { Route as AdminLoginRouteImport } from './routes/admin/login'
 import { Route as AdminStravaIndexRouteImport } from './routes/admin/strava/index'
@@ -37,6 +40,11 @@ import { Route as AdminAuthCallbackRouteImport } from './routes/admin/auth/callb
 import { Route as AdminRacesIdEditRouteImport } from './routes/admin/races/$id.edit'
 import { Route as AdminPrsIdEditRouteImport } from './routes/admin/prs/$id.edit'
 
+const ThoughtsRoute = ThoughtsRouteImport.update({
+  id: '/thoughts',
+  path: '/thoughts',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RunningRoute = RunningRouteImport.update({
   id: '/running',
   path: '/running',
@@ -72,10 +80,20 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ThoughtsIndexRoute = ThoughtsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ThoughtsRoute,
+} as any)
 const AdminIndexRoute = AdminIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AdminRouteRoute,
+} as any)
+const ThoughtsSlugRoute = ThoughtsSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => ThoughtsRoute,
 } as any)
 const AdminStreakRoute = AdminStreakRouteImport.update({
   id: '/streak',
@@ -181,9 +199,12 @@ export interface FileRoutesByFullPath {
   '/readme': typeof ReadmeRoute
   '/resume': typeof ResumeRoute
   '/running': typeof RunningRoute
+  '/thoughts': typeof ThoughtsRouteWithChildren
   '/admin/login': typeof AdminLoginRoute
   '/admin/streak': typeof AdminStreakRoute
+  '/thoughts/$slug': typeof ThoughtsSlugRoute
   '/admin/': typeof AdminIndexRoute
+  '/thoughts/': typeof ThoughtsIndexRoute
   '/admin/auth/callback': typeof AdminAuthCallbackRoute
   '/admin/google/callback': typeof AdminGoogleCallbackRoute
   '/admin/google/connect': typeof AdminGoogleConnectRoute
@@ -211,7 +232,9 @@ export interface FileRoutesByTo {
   '/running': typeof RunningRoute
   '/admin/login': typeof AdminLoginRoute
   '/admin/streak': typeof AdminStreakRoute
+  '/thoughts/$slug': typeof ThoughtsSlugRoute
   '/admin': typeof AdminIndexRoute
+  '/thoughts': typeof ThoughtsIndexRoute
   '/admin/auth/callback': typeof AdminAuthCallbackRoute
   '/admin/google/callback': typeof AdminGoogleCallbackRoute
   '/admin/google/connect': typeof AdminGoogleConnectRoute
@@ -239,9 +262,12 @@ export interface FileRoutesById {
   '/readme': typeof ReadmeRoute
   '/resume': typeof ResumeRoute
   '/running': typeof RunningRoute
+  '/thoughts': typeof ThoughtsRouteWithChildren
   '/admin/login': typeof AdminLoginRoute
   '/admin/streak': typeof AdminStreakRoute
+  '/thoughts/$slug': typeof ThoughtsSlugRoute
   '/admin/': typeof AdminIndexRoute
+  '/thoughts/': typeof ThoughtsIndexRoute
   '/admin/auth/callback': typeof AdminAuthCallbackRoute
   '/admin/google/callback': typeof AdminGoogleCallbackRoute
   '/admin/google/connect': typeof AdminGoogleConnectRoute
@@ -270,9 +296,12 @@ export interface FileRouteTypes {
     | '/readme'
     | '/resume'
     | '/running'
+    | '/thoughts'
     | '/admin/login'
     | '/admin/streak'
+    | '/thoughts/$slug'
     | '/admin/'
+    | '/thoughts/'
     | '/admin/auth/callback'
     | '/admin/google/callback'
     | '/admin/google/connect'
@@ -300,7 +329,9 @@ export interface FileRouteTypes {
     | '/running'
     | '/admin/login'
     | '/admin/streak'
+    | '/thoughts/$slug'
     | '/admin'
+    | '/thoughts'
     | '/admin/auth/callback'
     | '/admin/google/callback'
     | '/admin/google/connect'
@@ -327,9 +358,12 @@ export interface FileRouteTypes {
     | '/readme'
     | '/resume'
     | '/running'
+    | '/thoughts'
     | '/admin/login'
     | '/admin/streak'
+    | '/thoughts/$slug'
     | '/admin/'
+    | '/thoughts/'
     | '/admin/auth/callback'
     | '/admin/google/callback'
     | '/admin/google/connect'
@@ -357,10 +391,18 @@ export interface RootRouteChildren {
   ReadmeRoute: typeof ReadmeRoute
   ResumeRoute: typeof ResumeRoute
   RunningRoute: typeof RunningRoute
+  ThoughtsRoute: typeof ThoughtsRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/thoughts': {
+      id: '/thoughts'
+      path: '/thoughts'
+      fullPath: '/thoughts'
+      preLoaderRoute: typeof ThoughtsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/running': {
       id: '/running'
       path: '/running'
@@ -410,12 +452,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/thoughts/': {
+      id: '/thoughts/'
+      path: '/'
+      fullPath: '/thoughts/'
+      preLoaderRoute: typeof ThoughtsIndexRouteImport
+      parentRoute: typeof ThoughtsRoute
+    }
     '/admin/': {
       id: '/admin/'
       path: '/'
       fullPath: '/admin/'
       preLoaderRoute: typeof AdminIndexRouteImport
       parentRoute: typeof AdminRouteRoute
+    }
+    '/thoughts/$slug': {
+      id: '/thoughts/$slug'
+      path: '/$slug'
+      fullPath: '/thoughts/$slug'
+      preLoaderRoute: typeof ThoughtsSlugRouteImport
+      parentRoute: typeof ThoughtsRoute
     }
     '/admin/streak': {
       id: '/admin/streak'
@@ -603,6 +659,20 @@ const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
   AdminRouteRouteChildren,
 )
 
+interface ThoughtsRouteChildren {
+  ThoughtsSlugRoute: typeof ThoughtsSlugRoute
+  ThoughtsIndexRoute: typeof ThoughtsIndexRoute
+}
+
+const ThoughtsRouteChildren: ThoughtsRouteChildren = {
+  ThoughtsSlugRoute: ThoughtsSlugRoute,
+  ThoughtsIndexRoute: ThoughtsIndexRoute,
+}
+
+const ThoughtsRouteWithChildren = ThoughtsRoute._addFileChildren(
+  ThoughtsRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AdminRouteRoute: AdminRouteRouteWithChildren,
@@ -611,6 +681,7 @@ const rootRouteChildren: RootRouteChildren = {
   ReadmeRoute: ReadmeRoute,
   ResumeRoute: ResumeRoute,
   RunningRoute: RunningRoute,
+  ThoughtsRoute: ThoughtsRouteWithChildren,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/www/src/routes/thoughts.$slug.tsx
+++ b/apps/www/src/routes/thoughts.$slug.tsx
@@ -1,0 +1,55 @@
+import {createFileRoute, notFound} from '@tanstack/react-router';
+import {format} from 'date-fns';
+import {TagList} from '../components/thoughts/tag-list';
+import {ThoughtContent} from '../components/thoughts/thought-content';
+import {title} from '../config.shared';
+import type {Thought} from '../services/thoughts/thoughts-server';
+import {getThoughtBySlug} from '../services/thoughts/thoughts-server';
+
+type ThoughtLoaderData = {
+  thought: Thought;
+};
+
+export const Route = createFileRoute('/thoughts/$slug')({
+  component: ThoughtDetailPage,
+  head: ({loaderData}: {loaderData?: ThoughtLoaderData}) => {
+    if (!loaderData) return {};
+    return {
+      meta: [
+        {title: title(loaderData.thought.title)},
+        {name: 'description', content: loaderData.thought.description ?? ''},
+        {property: 'og:title', content: loaderData.thought.title},
+        {property: 'og:description', content: loaderData.thought.description ?? ''},
+        {property: 'og:type', content: 'article'},
+      ],
+    };
+  },
+  loader: async ({params}): Promise<ThoughtLoaderData> => {
+    const thought = await getThoughtBySlug({data: {slug: params.slug}});
+    if (!thought) throw notFound();
+    return {thought};
+  },
+});
+
+function ThoughtDetailPage() {
+  const {thought} = Route.useLoaderData();
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-24">
+      <h1 className="font-serif text-4xl text-warm-800">{thought.title}</h1>
+      {thought.published_at && (
+        <time className="mt-2 block text-sm text-warm-500">
+          {format(new Date(thought.published_at), 'MMMM d, yyyy')}
+        </time>
+      )}
+      {thought.tags && thought.tags.length > 0 && (
+        <div className="mt-3">
+          <TagList tags={thought.tags} />
+        </div>
+      )}
+      <div className="mt-8">
+        <ThoughtContent content={thought.content} />
+      </div>
+    </div>
+  );
+}

--- a/apps/www/src/routes/thoughts.index.tsx
+++ b/apps/www/src/routes/thoughts.index.tsx
@@ -1,0 +1,44 @@
+import {createFileRoute} from '@tanstack/react-router';
+import {title} from '../config.shared';
+import {getPublishedThoughts} from '../services/thoughts/thoughts-server';
+import {ThoughtCard} from '../components/thoughts/thought-card';
+
+export const Route = createFileRoute('/thoughts/')({
+  component: ThoughtsPage,
+  head: () => ({
+    meta: [
+      {title: title('Thoughts')},
+      {name: 'description', content: 'Thoughts and writings by Josh Gretz'},
+    ],
+  }),
+  loader: async () => {
+    const thoughts = await getPublishedThoughts();
+    return {thoughts};
+  },
+});
+
+function ThoughtsPage() {
+  const {thoughts} = Route.useLoaderData();
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-24">
+      <h1 className="mb-8 font-serif text-4xl text-warm-800">Thoughts</h1>
+      {thoughts.length === 0 ? (
+        <p className="text-warm-600">Nothing here yet.</p>
+      ) : (
+        <div className="space-y-6">
+          {thoughts.map((thought) => (
+            <ThoughtCard
+              key={thought.id}
+              title={thought.title}
+              slug={thought.slug}
+              description={thought.description}
+              tags={thought.tags}
+              published_at={thought.published_at!}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/www/src/routes/thoughts.tsx
+++ b/apps/www/src/routes/thoughts.tsx
@@ -1,0 +1,9 @@
+import {Outlet, createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/thoughts')({
+  component: ThoughtsLayout,
+});
+
+function ThoughtsLayout() {
+  return <Outlet />;
+}

--- a/apps/www/src/services/thoughts/thoughts-server.ts
+++ b/apps/www/src/services/thoughts/thoughts-server.ts
@@ -1,0 +1,47 @@
+import {createServerFn} from '@tanstack/react-start';
+
+export type Thought = {
+  id: number;
+  title: string;
+  slug: string;
+  content: string;
+  description: string | null;
+  tags: string[] | null;
+  published_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+function getEnv() {
+  return {
+    apiUrl: process.env.JOSHGRETZ_API_URL || 'http://localhost:3001',
+    apiToken: process.env.HELMET || '',
+  };
+}
+
+export const getPublishedThoughts = createServerFn({
+  method: 'GET',
+}).handler(async (): Promise<Thought[]> => {
+  const env = getEnv();
+  const response = await fetch(`${env.apiUrl}/thoughts/published`, {
+    headers: {Authorization: `Bearer ${env.apiToken}`},
+  });
+  if (!response.ok) throw new Error('Failed to fetch published thoughts');
+  return response.json();
+});
+
+export const getThoughtBySlug = createServerFn({
+  method: 'GET',
+})
+  .inputValidator((data: {slug: string}) => data)
+  .handler(async ({data}): Promise<Thought | null> => {
+    const env = getEnv();
+    const response = await fetch(`${env.apiUrl}/thoughts/slug/${data.slug}`, {
+      headers: {Authorization: `Bearer ${env.apiToken}`},
+    });
+    if (!response.ok) {
+      if (response.status === 404) return null;
+      throw new Error('Failed to fetch thought');
+    }
+    return response.json();
+  });

--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
         "clsx": "2.1.0",
         "date-fns": "^3.6.0",
         "isbot": "5.1.0",
+        "marked": "^17.0.4",
         "react": "18.2.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "18.2.0",
@@ -944,6 +945,8 @@
 
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
+    "marked": ["marked@17.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
@@ -1374,8 +1377,6 @@
 
     "joshgretz-tasks/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
-    "joshgretz-www/elysia": ["elysia@1.4.22", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.6", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Q90VCb1RVFxnFaRV0FDoSylESQQLWgLHFmWciQJdX9h3b2cSasji9KWEUvaJuy/L9ciAGg4RAhUVfsXHg5K2RQ=="],
-
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -1487,8 +1488,6 @@
     "jobs/@types/bun/bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
 
     "joshgretz-apps-301/elysia/exact-mirror": ["exact-mirror@0.2.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-7s059UIx9/tnOKSySzUk5cPGkoILhTE4p6ncf6uIPaQ+9aRBQzQjc9+q85l51+oZ+P6aBxh084pD0CzBQPcFUA=="],
-
-    "joshgretz-www/elysia/exact-mirror": ["exact-mirror@0.2.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-7s059UIx9/tnOKSySzUk5cPGkoILhTE4p6ncf6uIPaQ+9aRBQzQjc9+q85l51+oZ+P6aBxh084pD0CzBQPcFUA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 


### PR DESCRIPTION
## Summary
- Add `/thoughts` list page showing published thoughts
- Add `/thoughts/$slug` detail page with markdown rendering via `marked`
- SEO meta tags and OG tags on detail pages
- Server functions for fetching published thoughts and by slug
- Reusable ThoughtCard, ThoughtContent, and TagList components

## Test plan
- [ ] `/thoughts` renders list of published thoughts
- [ ] `/thoughts/:slug` renders markdown content with correct SEO meta
- [ ] 404 for non-existent slugs
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)