### PR TITLE
feat(files): add download button to public file renderer

### DIFF
--- a/apps/api/src/routes/files-public.ts
+++ b/apps/api/src/routes/files-public.ts
@@ -1,22 +1,42 @@
 import {Elysia, t} from 'elysia';
 import {findFileBySlug} from 'files';
 
+// Strip bytes that would break a quoted Content-Disposition filename: control
+// chars (incl. CR/LF) and DEL, plus double quotes and backslashes.
+const UNSAFE_FILENAME_CHARS = new RegExp('[\\x00-\\x1f\\x7f"\\\\]', 'g');
+
+// Build a Content-Disposition: attachment header from an arbitrary filename.
+// Provides a sanitized ASCII `filename="..."` plus an RFC 5987 `filename*`
+// form so non-ASCII names survive intact.
+function attachmentDisposition(filename: string): string {
+  const ascii = filename.replace(UNSAFE_FILENAME_CHARS, '');
+  const encoded = encodeURIComponent(filename);
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}
+
 // Public (unauthenticated) raw file bytes. Uploaded files are shareable by URL,
 // so this route lives OUTSIDE the bearer guard and is consumed directly as an
-// <img> source by the public /files/{slug} page.
+// <img> source by the public /files/{slug} page. The ?download flag adds a
+// Content-Disposition header so cross-origin anchors reliably save the file
+// (the HTML download attribute is ignored across origins).
 export default new Elysia({prefix: '/files'}).get(
   '/raw/:slug',
-  async ({params: {slug}}) => {
+  async ({params: {slug}, query: {download}}) => {
     const file = await findFileBySlug(slug);
     if (!file) {
       return new Response('Not found', {status: 404});
     }
-    return new Response(file.data, {
-      headers: {
-        'Content-Type': file.mime_type,
-        'Cache-Control': 'public, max-age=3600',
-      },
-    });
+    const headers: Record<string, string> = {
+      'Content-Type': file.mime_type,
+      'Cache-Control': 'public, max-age=3600',
+    };
+    if (download) {
+      headers['Content-Disposition'] = attachmentDisposition(file.original_filename);
+    }
+    return new Response(file.data, {headers});
   },
-  {params: t.Object({slug: t.String()})},
+  {
+    params: t.Object({slug: t.String()}),
+    query: t.Object({download: t.Optional(t.String())}),
+  },
 );

--- a/apps/api/src/routes/files-public.ts
+++ b/apps/api/src/routes/files-public.ts
@@ -1,15 +1,16 @@
 import {Elysia, t} from 'elysia';
 import {findFileBySlug} from 'files';
 
-// Strip bytes that would break a quoted Content-Disposition filename: control
-// chars (incl. CR/LF) and DEL, plus double quotes and backslashes.
-const UNSAFE_FILENAME_CHARS = new RegExp('[\\x00-\\x1f\\x7f"\\\\]', 'g');
+// Anything outside printable ASCII (0x20–0x7e) is invalid in a quoted
+// Content-Disposition `filename`; this also drops double quotes and backslashes
+// that would break the quoting. Non-ASCII names are preserved via `filename*`.
+const NON_ASCII_FILENAME_CHARS = /[^\x20-\x7e]|["\\]/g;
 
 // Build a Content-Disposition: attachment header from an arbitrary filename.
-// Provides a sanitized ASCII `filename="..."` plus an RFC 5987 `filename*`
-// form so non-ASCII names survive intact.
+// Provides an ASCII `filename="..."` fallback plus an RFC 5987 `filename*`
+// form so non-ASCII names survive intact in browsers that support it.
 function attachmentDisposition(filename: string): string {
-  const ascii = filename.replace(UNSAFE_FILENAME_CHARS, '');
+  const ascii = filename.replace(NON_ASCII_FILENAME_CHARS, '');
   const encoded = encodeURIComponent(filename);
   return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
 }

--- a/apps/www/src/routes/files.$slug.tsx
+++ b/apps/www/src/routes/files.$slug.tsx
@@ -1,5 +1,6 @@
 import {createFileRoute, notFound} from '@tanstack/react-router';
 import {ThoughtContent} from '../components/thoughts/thought-content';
+import {Button} from '../components/ui/button';
 import {title} from '../config.shared';
 import {getApiUrl} from '../services/api-client';
 import {type FileDetail, getFileBySlug} from '../services/files/files-server';
@@ -25,22 +26,28 @@ export const Route = createFileRoute('/files/$slug')({
 
 function FilePage() {
   const {file} = Route.useLoaderData();
-
-  if (file.kind === 'image') {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-warm-50 p-6">
-        <img
-          src={`${getApiUrl()}/files/raw/${file.slug}`}
-          alt={file.original_filename}
-          className="max-h-full max-w-full"
-        />
-      </div>
-    );
-  }
+  const downloadUrl = `${getApiUrl()}/files/raw/${file.slug}?download=1`;
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-24">
-      <ThoughtContent content={file.content ?? ''} />
-    </div>
+    <>
+      <div className="fixed right-4 top-4 z-10">
+        <Button asChild variant="outline" size="sm">
+          <a href={downloadUrl}>Download</a>
+        </Button>
+      </div>
+      {file.kind === 'image' ? (
+        <div className="flex min-h-screen items-center justify-center bg-warm-50 p-6">
+          <img
+            src={`${getApiUrl()}/files/raw/${file.slug}`}
+            alt={file.original_filename}
+            className="max-h-full max-w-full"
+          />
+        </div>
+      ) : (
+        <div className="mx-auto max-w-2xl px-6 py-24">
+          <ThoughtContent content={file.content ?? ''} />
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Adds a **Download** button to the top of the public `/files/{slug}` renderer, shared by both the image and markdown render paths, and extends the public raw-bytes route to force a download when requested.

## Why

The renderer (`www`) and the raw-bytes API are on **different origins** in production (joshgretz.com vs `joshgretz-api.fly.dev`). The HTML `download` attribute on an anchor is **ignored by browsers for cross-origin URLs** — the browser displays the file inline instead of saving it. So the download must be forced server-side via a `Content-Disposition: attachment` header.

## Changes

- **API** (`apps/api/src/routes/files-public.ts`): `GET /files/raw/:slug` now reads an optional `?download` query flag. When present, it adds a `Content-Disposition: attachment` header built from the file's `original_filename`, with both a sanitized ASCII `filename="..."` and an RFC 5987 `filename*=UTF-8''...` form for non-ASCII names. The inline path (no flag) is byte-for-byte unchanged — same `Content-Type` and `Cache-Control`, no `Content-Disposition`.
- **WWW** (`apps/www/src/routes/files.$slug.tsx`): both render branches are wrapped so a single fixed top-right `Button asChild` anchor pointing at `${getApiUrl()}/files/raw/${slug}?download=1` renders in both. Reuses the existing `Button` (`variant="outline" size="sm"`).

## Verification

- `cd apps/www && bun run typecheck` — passes.
- `cd apps/www && bun run lint` (Biome) — passes.
- API: no new TypeScript errors (the lone `Cannot find module 'files'` resolution error is pre-existing and also present on the untouched `files.ts`/`index.ts`).
- Header construction verified at runtime for plain, quoted/control-char, and Unicode filenames.

curl checks (run against a live slug):
```
curl -sD - "http://localhost:3001/files/raw/<slug>?download=1" -o /dev/null  # content-disposition: attachment present
curl -sD - "http://localhost:3001/files/raw/<slug>" -o /dev/null             # no content-disposition
```